### PR TITLE
Separated EC math logic from extended key implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "nl_tulipsolutions_bitcoin_tools",
-    commit = "b25a2615d94d7d18c46ec27a16330f7891b8b893",
+    commit = "1a78849d243d2e2834eb2c80276863ed5746f6c8",
     remote = "https://github.com/TulipSolutions/bitcoin-tools",
 )
 ```
@@ -74,11 +74,16 @@ See also [example Build.bazel](examples/src/main/kotlin/com/example/simpleprojec
 3. The extended key wrapper can be used as follow:
 
 ```kotlin
+import nl.tulipsolutions.BCmath.ECMathProviderImpl
+// Choose your ECmath implementation
+// in this case we use bouncy castle
+val ecMathProvider = ECMathProviderImpl
+
 // m
 val zpriv = "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE"
 // The wrapper currently supports xpriv, xpub, tpub, tpriv which will enforce BIP32Serde
 // It also supports zpriv, zpub, vpriv, vpub which will enforce BIP84Serde
-val extendedKey = ExtendedKeyWrapper(zpriv)
+val extendedKey = ExtendedKeyWrapper(ecMathProvider, zpriv)
 println(extendedKey.getAddress())
 println(extendedKey.serializeExtKey())
 println(extendedKey.getPublicKey())
@@ -103,6 +108,7 @@ println(childOfChild.getPublicKey())
 val mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 val passphrase = ""
 val extendedKeyFromMnemonic = ExtendedKeyWrapper(
+    ecMathProvider,
     seed = vector.mnemonic.split(" ").toSeed(passphrase),
     serde = Bip32Serde(),
     isMainNet = true
@@ -118,4 +124,5 @@ See also [example Main.kt](examples/src/main/kotlin/com/example/simpleproject/Ma
 - Signing: Same reason why we did not implement new private key generation
 - Implementation of derivation based on a keypath string
 - p2wpkh in P2SH
-- Move EC math to a separate class and use an interface to allow the developer to choose his preferred implementation.
+- Add libsecp256 c bindings and alternative ecmath implemenation provider
+

--- a/examples/src/main/kotlin/com/example/simpleproject/BUILD.bazel
+++ b/examples/src/main/kotlin/com/example/simpleproject/BUILD.bazel
@@ -5,6 +5,7 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     visibility = ["//examples:__subpackages__"],
     deps = [
+        "@nl_tulipsolutions_bitcoin_tools//src/main/kotlin/nl/tulipsolutions/BCmath",
         "@nl_tulipsolutions_bitcoin_tools//src/main/kotlin/nl/tulipsolutions/keyderivation",
         "@nl_tulipsolutions_bitcoin_tools//src/main/kotlin/nl/tulipsolutions/mnemonic",
     ],

--- a/examples/src/main/kotlin/com/example/simpleproject/Main.kt
+++ b/examples/src/main/kotlin/com/example/simpleproject/Main.kt
@@ -15,6 +15,7 @@
 package com.example.simpleproject
 
 import java.lang.RuntimeException
+import nl.tulipsolutions.BCmath.ECMathProviderImpl
 import nl.tulipsolutions.keyderivation.Bip32Serde
 import nl.tulipsolutions.keyderivation.Bip44Serde
 import nl.tulipsolutions.keyderivation.Bip84Serde
@@ -38,20 +39,21 @@ fun help() {
     println("Example: fromSeed bip32 main TREZOR \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"")
 }
 
+val ecMathProvider = ECMathProviderImpl
 fun main(args: Array<String>) {
 
     if (args.isEmpty() || args[0] == "help") {
         help()
     } else if (args[0] == "derive") {
-        val key = ExtendedKeyWrapper(args[1])
-        val leafChild = deriveChildren(args.drop(2), key)
+        val key = ExtendedKeyWrapper(ecMathProvider, args[0])
+        val leafChild = deriveChildren(args.drop(1), key)
         println("Address: ${leafChild.getAddress()}")
         println("ExtendedKey: ${leafChild.serializeExtKey()}")
     } else if (args[0] == "fromSeed") {
         val serde: Pair<ExtendedKeySerdeInterface, Int> = when (args[1]) {
-            "bip32" -> Pair(Bip32Serde(), 0)
-            "bip44" -> Pair(Bip44Serde(), Bip44Serde().purpose)
-            "bip84" -> Pair(Bip84Serde(), Bip84Serde().purpose)
+            "bip32" -> Pair(Bip32Serde(ecMathProvider), 0)
+            "bip44" -> Pair(Bip44Serde(ecMathProvider), Bip44Serde(ecMathProvider).purpose)
+            "bip84" -> Pair(Bip84Serde(ecMathProvider), Bip84Serde(ecMathProvider).purpose)
             else -> throw RuntimeException("Invalid arg expected one of ${availableSerdes.joinToString(" | ")} was $args[1]")
         }
         val isMain = when (args[2]) {
@@ -60,7 +62,7 @@ fun main(args: Array<String>) {
             else -> throw RuntimeException("Invalid arg expected one of ${network.joinToString(" | ")} was $args[1]")
         }
         var path = "m/"
-        val rootKey = ExtendedKeyWrapper(args[4].split(" ").toSeed(args[3]), serde.first, isMain)
+        val rootKey = ExtendedKeyWrapper(ecMathProvider, args[4].split(" ").toSeed(args[3]), serde.first, isMain)
         println("Path: $path")
         println("Master ExtendedKey: ${rootKey.serializeExtKey()}")
 

--- a/src/main/kotlin/nl/tulipsolutions/BCmath/BUILD.bazel
+++ b/src/main/kotlin/nl/tulipsolutions/BCmath/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "BCmath",
+    srcs = glob(["*.kt"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/kotlin/nl/tulipsolutions/keyderivation",
+        "@maven//:org_bouncycastle_bcprov_jdk15on",
+    ],
+)

--- a/src/main/kotlin/nl/tulipsolutions/BCmath/ECMathProviderImpl.kt
+++ b/src/main/kotlin/nl/tulipsolutions/BCmath/ECMathProviderImpl.kt
@@ -1,0 +1,55 @@
+package nl.tulipsolutions.BCmath
+
+import java.math.BigInteger
+import nl.tulipsolutions.keyderivation.ECMathProvider
+import nl.tulipsolutions.keyderivation.ECPointWrapper
+import org.bouncycastle.asn1.sec.SECNamedCurves
+import org.bouncycastle.asn1.x9.X9ECParameters
+import org.bouncycastle.crypto.params.ECDomainParameters
+
+object ECMathProviderImpl : ECMathProvider {
+    @JvmStatic
+    private val curveParams: X9ECParameters = SECNamedCurves.getByName("secp256k1")
+
+    @JvmStatic
+    private val domain: ECDomainParameters =
+        ECDomainParameters(curveParams.curve, curveParams.g, curveParams.n, curveParams.h)
+
+    override val curveN: BigInteger
+        get() = curveParams.n
+
+    /**
+     * Takes an BigInteger does an EC multiplication with curve Generator and creates a new ECPointWrapper
+     *
+     * @param value the [BigInteger] value to multiply with
+     * @return [ECPointWrapperImpl]
+     */
+    override fun multiplyByG(value: BigInteger): ECPointWrapperImpl {
+        return ECPointWrapperImpl(this.curveParams.g.multiply(value))
+    }
+
+    /**
+     * Takes an encoded point converts it to a bouncycastle ECPoint and returns the handler
+     *
+     * @param encodedPoint encoded ECpoint
+     * @return [ECPointWrapperImpl]
+     */
+    override fun decodePoint(encodedPoint: ByteArray): ECPointWrapper =
+        ECPointWrapperImpl(this.curveParams.curve.decodePoint(encodedPoint))
+
+    /**
+     * Public point verification
+     * raises the errors if any otherwise it will return the wrapper
+     *
+     * @param wrappedPoint wrapped ECpoint
+     * @return [ECPointWrapperImpl]
+     */
+    override fun validatePublicPoint(wrappedPoint: ECPointWrapper): ECPointWrapper {
+        try {
+            this.domain.validatePublicPoint((wrappedPoint as ECPointWrapperImpl).point)
+        } catch (e: RuntimeException) {
+            throw e
+        }
+        return wrappedPoint
+    }
+}

--- a/src/main/kotlin/nl/tulipsolutions/BCmath/ECMathProviderImpl.kt
+++ b/src/main/kotlin/nl/tulipsolutions/BCmath/ECMathProviderImpl.kt
@@ -1,3 +1,17 @@
+// Copyright 2020 Tulip Solutions B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nl.tulipsolutions.BCmath
 
 import java.math.BigInteger

--- a/src/main/kotlin/nl/tulipsolutions/BCmath/ECPointWrapperImpl.kt
+++ b/src/main/kotlin/nl/tulipsolutions/BCmath/ECPointWrapperImpl.kt
@@ -1,3 +1,17 @@
+// Copyright 2020 Tulip Solutions B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nl.tulipsolutions.BCmath
 
 import nl.tulipsolutions.keyderivation.ECPointWrapper

--- a/src/main/kotlin/nl/tulipsolutions/BCmath/ECPointWrapperImpl.kt
+++ b/src/main/kotlin/nl/tulipsolutions/BCmath/ECPointWrapperImpl.kt
@@ -1,0 +1,23 @@
+package nl.tulipsolutions.BCmath
+
+import nl.tulipsolutions.keyderivation.ECPointWrapper
+import org.bouncycastle.math.ec.ECPoint
+
+data class ECPointWrapperImpl(val point: ECPoint) : ECPointWrapper {
+    /**
+     * Takes a ECPointHandler, bouncycastle EC sum and returns a new ECPointWrapper
+     *
+     * @param wrappedPoint encoded ECpoint
+     * @return [ECPointWrapperImpl]
+     */
+    override fun add(wrappedPoint: ECPointWrapper): ECPointWrapper =
+        ECPointWrapperImpl(point.add((wrappedPoint as ECPointWrapperImpl).point))
+
+    /**
+     * Returns the ECPoint in encoded format
+     *
+     * @param derEncoded whether or not to use DER encoding
+     * @return [ByteArray]
+     */
+    override fun getEncoded(derEncoded: Boolean): ByteArray = point.getEncoded(derEncoded)
+}

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/Bip44Serde.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/Bip44Serde.kt
@@ -18,23 +18,17 @@ import nl.tulipsolutions.byteutils.ZERO_BYTE
 
 // See: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 open class Bip44Serde(
-    val purpose: Int = 44,
-    private val MAINNET_PUBLIC_CODE: ByteArray = this.MAINNET_PUBLIC_CODE,
-    private val MAINNET_PRIVATE_CODE: ByteArray = this.MAINNET_PRIVATE_CODE,
-    private val TESTNET_PUBLIC_CODE: ByteArray = this.TESTNET_PUBLIC_CODE,
-    private val TESTNET_PRIVATE_CODE: ByteArray = this.TESTNET_PRIVATE_CODE
-) : Bip32Serde(
-    MAINNET_PUBLIC_CODE, MAINNET_PRIVATE_CODE,
-    TESTNET_PUBLIC_CODE, TESTNET_PRIVATE_CODE
-) {
+    ecMathProvider: ECMathProvider,
+    val purpose: Int = 44
+) : Bip32Serde(ecMathProvider) {
 
-    private val PURPOSE_VALUE = HARDENED_KEY_ZERO + purpose
+    private fun purposeValue() = HARDENED_KEY_ZERO + purpose
 
     // BIP44 only introduces a derivation path spec m / purpose' / coin_type' / account' / change / address_index
     override fun deriveChildBIPRules(extendedKey: ExtendedKey, sequence: Int): ExtendedKey {
         if (extendedKey.depth.toInt() in 0..2 && sequence.and(HARDENED_KEY_ZERO) == 0) {
             throw HardenedDerivationRequiredException(extendedKey.depth.toInt(), sequence)
-        } else if (extendedKey.depth == ZERO_BYTE && sequence != PURPOSE_VALUE) {
+        } else if (extendedKey.depth == ZERO_BYTE && sequence != purposeValue()) {
             throw InvalidPurposeException(purpose, sequence)
         }
         return extendedKey.deriveChild(sequence)

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/Bip84Serde.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/Bip84Serde.kt
@@ -18,28 +18,25 @@ package nl.tulipsolutions.keyderivation
     Bip84 uses the same underlying structure as bip32 it only encodes addresses differently ( bech32 instead of base58 ).
     The BIP is specifically aimed a derivation structures for segwit.
  */
-class Bip84Serde : Bip44Serde(
-    84,
-    this.MAINNET_PUBLIC_CODE, this.MAINNET_PRIVATE_CODE,
-    this.TESTNET_PUBLIC_CODE, this.TESTNET_PRIVATE_CODE
-) {
+open class Bip84Serde(
+    ecMathProvider: ECMathProvider
+) : Bip44Serde(ecMathProvider, 84) {
 
     companion object {
-        private val MAINNET_CODE = byteArrayOf(0x04.toByte(), 0xb2.toByte())
-        private val TESTNET_CODE = byteArrayOf(0x04.toByte(), 0x5f.toByte())
-
-        @JvmStatic
+        val MAINNET_CODE = byteArrayOf(0x04.toByte(), 0xb2.toByte())
+        val TESTNET_CODE = byteArrayOf(0x04.toByte(), 0x5f.toByte())
         val MAINNET_PUBLIC_CODE = MAINNET_CODE + byteArrayOf(0x47.toByte(), 0x46.toByte())
-
-        @JvmStatic
         val MAINNET_PRIVATE_CODE = MAINNET_CODE + byteArrayOf(0x43.toByte(), 0x0C.toByte())
-
-        @JvmStatic
         val TESTNET_PUBLIC_CODE = TESTNET_CODE + byteArrayOf(0x1C.toByte(), 0xF6.toByte())
-
-        @JvmStatic
         val TESTNET_PRIVATE_CODE = TESTNET_CODE + byteArrayOf(0x18.toByte(), 0xbc.toByte())
     }
+
+    override val MAINNET_CODE = Companion.MAINNET_CODE
+    override val TESTNET_CODE = Companion.TESTNET_CODE
+    override val MAINNET_PUBLIC_CODE = Companion.MAINNET_PUBLIC_CODE
+    override val MAINNET_PRIVATE_CODE = Companion.MAINNET_PRIVATE_CODE
+    override val TESTNET_PUBLIC_CODE = Companion.TESTNET_PUBLIC_CODE
+    override val TESTNET_PRIVATE_CODE = Companion.TESTNET_PRIVATE_CODE
 
     override fun getNetCodeAndType(isMainNet: Boolean, isPrivate: Boolean): ByteArray =
         if (isMainNet) {
@@ -56,7 +53,7 @@ class Bip84Serde : Bip44Serde(
         if (extendedKey.depth.toInt() != 5) {
             throw InvalidDepthException(5, extendedKey.depth.toInt())
         }
-        val program = this.hash160(extendedKey).toList().map { it.toInt() and 0xff }
+        val program = super.hash160(extendedKey).toList().map { it.toInt() and 0xff }
         val version = 0.toByte()
         val netCodeAndType = extendedKey.netAndTypeCode
         return when {

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/ECMathProvider.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/ECMathProvider.kt
@@ -1,3 +1,17 @@
+// Copyright 2020 Tulip Solutions B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nl.tulipsolutions.keyderivation
 
 import java.math.BigInteger

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/ECMathProvider.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/ECMathProvider.kt
@@ -1,0 +1,10 @@
+package nl.tulipsolutions.keyderivation
+
+import java.math.BigInteger
+
+interface ECMathProvider {
+    fun multiplyByG(value: BigInteger): ECPointWrapper
+    val curveN: BigInteger
+    fun decodePoint(encodedPoint: ByteArray): ECPointWrapper
+    fun validatePublicPoint(wrappedPoint: ECPointWrapper): ECPointWrapper
+}

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/ECPointWrapper.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/ECPointWrapper.kt
@@ -1,3 +1,17 @@
+// Copyright 2020 Tulip Solutions B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nl.tulipsolutions.keyderivation
 
 /**

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/ECPointWrapper.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/ECPointWrapper.kt
@@ -1,0 +1,11 @@
+package nl.tulipsolutions.keyderivation
+
+/**
+ * Abstract ECPoint interface
+ * Used to separate EC math implementation to allow a selection of libraries E.G: LibSecp256k1, BouncyCastle etc
+ */
+interface ECPointWrapper {
+
+    fun add(wrappedPoint: ECPointWrapper): ECPointWrapper
+    fun getEncoded(derEncoded: Boolean): ByteArray
+}

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/ExtendedKeySerdeInterface.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/ExtendedKeySerdeInterface.kt
@@ -15,11 +15,25 @@
 package nl.tulipsolutions.keyderivation
 
 interface ExtendedKeySerdeInterface {
-    fun getNetCodeAndType(isMainNet: Boolean, isPrivate: Boolean): ByteArray
+
     fun getAddress(extendedKey: ExtendedKey): String
     fun serializeExtKey(extendedKey: ExtendedKey): String
     fun toHexString(extendedKey: ExtendedKey): String
     fun deSerializeExtKey(extKeyBytes: ByteArray): ExtendedKey
     fun deSerializeExtKey(extKeyEncoded: String): ExtendedKey
     fun deriveChildBIPRules(extendedKey: ExtendedKey, sequence: Int): ExtendedKey
+    fun hash160(extendedKey: ExtendedKey): ByteArray
+
+    fun getNetCodeAndType(isMainNet: Boolean, isPrivate: Boolean): ByteArray
+
+    val MAINNET_CODE: ByteArray
+    val TESTNET_CODE: ByteArray
+
+    val MAINNET_PUBLIC_CODE: ByteArray
+
+    val MAINNET_PRIVATE_CODE: ByteArray
+
+    val TESTNET_PUBLIC_CODE: ByteArray
+
+    val TESTNET_PRIVATE_CODE: ByteArray
 }

--- a/src/main/kotlin/nl/tulipsolutions/keyderivation/ExtendedKeyWrapper.kt
+++ b/src/main/kotlin/nl/tulipsolutions/keyderivation/ExtendedKeyWrapper.kt
@@ -31,40 +31,40 @@ class ExtendedKeyWrapper {
         this.extendedKey = extendedKey
     }
 
-    constructor(extKeyString: String) {
+    constructor(ecMathProvider: ECMathProvider, extKeyString: String) {
         when (
             val netAndTypeCode = extKeyString.substring(0, 4)) {
             "xprv",
             "xpub",
             "tprv",
             "tpub" -> {
-                serde = Bip32Serde()
+                serde = Bip32Serde(ecMathProvider)
             }
             "zprv",
             "zpub",
             "vprv",
             "vpub" -> {
-                serde = Bip84Serde()
+                serde = Bip84Serde(ecMathProvider)
             }
             else -> throw RuntimeException("Extended Key type: $netAndTypeCode, not supported")
         }
         extendedKey = serde.deSerializeExtKey(extKeyString)
     }
 
-    constructor(extKeyBytes: ByteArray) {
+    constructor(ecMathProvider: ECMathProvider, extKeyBytes: ByteArray) {
         val netAndTypeCode = extKeyBytes.copyOfRange(0, 4)
         when {
             netAndTypeCode.contentEquals(Bip32Serde.MAINNET_PUBLIC_CODE) ||
                 netAndTypeCode.contentEquals(Bip32Serde.MAINNET_PRIVATE_CODE) ||
                 netAndTypeCode.contentEquals(Bip32Serde.TESTNET_PUBLIC_CODE) ||
                 netAndTypeCode.contentEquals(Bip32Serde.TESTNET_PRIVATE_CODE) -> {
-                serde = Bip32Serde()
+                serde = Bip32Serde(ecMathProvider)
             }
             netAndTypeCode.contentEquals(Bip84Serde.MAINNET_PUBLIC_CODE) ||
                 netAndTypeCode.contentEquals(Bip84Serde.MAINNET_PRIVATE_CODE) ||
                 netAndTypeCode.contentEquals(Bip84Serde.TESTNET_PUBLIC_CODE) ||
                 netAndTypeCode.contentEquals(Bip84Serde.TESTNET_PRIVATE_CODE) -> {
-                serde = Bip84Serde()
+                serde = Bip84Serde(ecMathProvider)
             }
             else -> throw RuntimeException("Type and net code: $netAndTypeCode, not supported")
         }
@@ -80,6 +80,7 @@ class ExtendedKeyWrapper {
      * @return [ExtendedKey]
      */
     constructor(
+        ecMathProvider: ECMathProvider,
         seed: ByteArray,
         serde: ExtendedKeySerdeInterface,
         isMainNet: Boolean = false
@@ -104,7 +105,8 @@ class ExtendedKeyWrapper {
             // Pad the private key part
             privateKey = byteArrayOf(0x00) + hmacSeed.sliceArray(0..31),
             _publicKey = null,
-            chainCode = hmacSeed.sliceArray(32..63)
+            chainCode = hmacSeed.sliceArray(32..63),
+            ecMathProvider = ecMathProvider
         )
     }
 

--- a/src/test/kotlin/nl/tulipsolutions/keyderivation/BUILD.bazel
+++ b/src/test/kotlin/nl/tulipsolutions/keyderivation/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 deps = [
     "//src/main/kotlin/nl/tulipsolutions/keyderivation",
     "//src/main/kotlin/nl/tulipsolutions/byteutils",
+    "//src/main/kotlin/nl/tulipsolutions/BCmath",
     "@maven//:junit_junit",
     "@maven//:org_assertj_assertj_core",
 ]

--- a/src/test/kotlin/nl/tulipsolutions/keyderivation/Bip32SerdeTest.kt
+++ b/src/test/kotlin/nl/tulipsolutions/keyderivation/Bip32SerdeTest.kt
@@ -14,12 +14,15 @@
 
 package nl.tulipsolutions.keyderivation
 
+import nl.tulipsolutions.BCmath.ECMathProviderImpl
 import nl.tulipsolutions.byteutils.Hex
 import org.assertj.core.api.Assertions
 import org.junit.Test
 
 @kotlin.ExperimentalUnsignedTypes
 class Bip32SerdeTest {
+
+    val ecMathProvider = ECMathProviderImpl
 
     // Test vectors from https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#test-vector-1
     private val testVec1MxPrivEncoded = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg" +
@@ -36,7 +39,8 @@ class Bip32SerdeTest {
         childNumber = byteArrayOf(0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()),
         chainCode = Hex.decode("873DFF81C02F525623FD1FE5167EAC3A55A049DE3D314BB42EE227FFED37D508"),
         _publicKey = Hex.decode("0339A36013301597DAEF41FBE593A02CC513D0B55527EC2DF1050E2E8FF49C85C2"),
-        privateKey = null
+        privateKey = null,
+        ecMathProvider = ecMathProvider
     )
     private val testVec1M0HXPrivEncoded = "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesn" +
         "DYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7"
@@ -68,7 +72,8 @@ class Bip32SerdeTest {
         "0488B21E05D880D7D83B9ACA00C783E67B921D2BEB8F6B389CC646D7263B4145701DADD2161548A8B078E65E9E022A471424DA5E6574" +
             "99D1FF51CB43C47481A03B1E77F951FE64CEC9F5A48F701118" +
             "D3A268"
-    private val serde = Bip32Serde()
+
+    private val serde = Bip32Serde(ecMathProvider)
 
     @Test
     fun testMasterSerializeKey() {
@@ -108,7 +113,8 @@ class Bip32SerdeTest {
             chainCode = Hex.decode("0000000000000000000000000000000000000000000000000000000000000000"),
             // Note invalid and unused chaincode
             _publicKey = Hex.decode("0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352"),
-            privateKey = null
+            privateKey = null,
+            ecMathProvider = ecMathProvider
         )
         val master = serde.getAddress(testKey)
         Assertions.assertThat(
@@ -128,7 +134,8 @@ class Bip32SerdeTest {
             childNumber = byteArrayOf(0x80.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()),
             chainCode = Hex.decode("47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141"),
             _publicKey = Hex.decode("035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56"),
-            privateKey = null
+            privateKey = null,
+            ecMathProvider = ecMathProvider
         )
         Assertions.assertThatThrownBy { master.deriveChild(HARDENED_KEY_ZERO) }
             .hasMessage("Deriving a hardened key requires a private key")
@@ -146,7 +153,8 @@ class Bip32SerdeTest {
             childNumber = byteArrayOf(0x80.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()),
             chainCode = Hex.decode("47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141"),
             _publicKey = Hex.decode("035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56"),
-            privateKey = Hex.decode("00edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea")
+            privateKey = Hex.decode("00edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea"),
+            ecMathProvider = ecMathProvider
         )
         Assertions.assertThat(master.deriveChild(HARDENED_KEY_ZERO)).isEqualToComparingFieldByField(expected)
     }
@@ -163,7 +171,8 @@ class Bip32SerdeTest {
             childNumber = byteArrayOf(0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x01.toByte()),
             chainCode = Hex.decode("2a7857631386ba23dacac34180dd1983734e444fdbf774041578e9b6adb37c19"),
             _publicKey = Hex.decode("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c"),
-            privateKey = null
+            privateKey = null,
+            ecMathProvider = ecMathProvider
         )
         Assertions.assertThat(master.deriveChild(1)).isEqualToComparingFieldByField(expected)
     }
@@ -180,7 +189,8 @@ class Bip32SerdeTest {
             childNumber = byteArrayOf(0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x01.toByte()),
             chainCode = Hex.decode("2a7857631386ba23dacac34180dd1983734e444fdbf774041578e9b6adb37c19"),
             _publicKey = Hex.decode("03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c"),
-            privateKey = Hex.decode("003c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368")
+            privateKey = Hex.decode("003c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368"),
+            ecMathProvider = ecMathProvider
         )
         Assertions.assertThat(master.deriveChild(1)).isEqualToComparingFieldByField(expected)
     }
@@ -205,7 +215,8 @@ class Bip32SerdeTest {
             childNumber = byteArrayOf(0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x02.toByte()),
             chainCode = Hex.decode("cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd"),
             _publicKey = Hex.decode("02e8445082a72f29b75ca48748a914df60622a609cacfce8ed0e35804560741d29"),
-            privateKey = null
+            privateKey = null,
+            ecMathProvider = ecMathProvider
         )
         Assertions.assertThat(master.deriveChild(2)).isEqualTo(expected)
     }
@@ -222,7 +233,8 @@ class Bip32SerdeTest {
             childNumber = Hex.decode("3b9aca00"),
             chainCode = Hex.decode("c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e"),
             _publicKey = Hex.decode("022a471424da5e657499d1ff51cb43c47481a03b1e77f951fe64cec9f5a48f7011"),
-            privateKey = null
+            privateKey = null,
+            ecMathProvider = ecMathProvider
         )
         Assertions.assertThat(master.deriveChild(1000000000)).isEqualTo(expected)
     }
@@ -241,7 +253,8 @@ class Bip32SerdeTest {
         childNumber = byteArrayOf(0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()),
         chainCode = Hex.decode("01D28A3E53CFFA419EC122C968B3259E16B65076495494D97CAE10BBFEC3C36F"),
         _publicKey = Hex.decode("03683AF1BA5743BDFC798CF814EFEEAB2735EC52D95ECED528E692B8E34C4E5669"),
-        privateKey = null
+        privateKey = null,
+        ecMathProvider = ecMathProvider
     )
     private val testVec3PrivateExtendedKey = ExtendedKey(
         parentKey = null,
@@ -251,7 +264,8 @@ class Bip32SerdeTest {
         childNumber = byteArrayOf(0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte()),
         chainCode = Hex.decode("01d28a3e53cffa419ec122c968b3259e16b65076495494d97cae10bbfec3c36f"),
         _publicKey = null,
-        privateKey = Hex.decode("0000ddb80b067e0d4993197fe10f2657a844a384589847602d56f0c629c81aae32")
+        privateKey = Hex.decode("0000ddb80b067e0d4993197fe10f2657a844a384589847602d56f0c629c81aae32"),
+        ecMathProvider = ecMathProvider
     )
 
     val testVec3Master0HxPubEncoded = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNL" +

--- a/src/test/kotlin/nl/tulipsolutions/keyderivation/Bip84SerdeTest.kt
+++ b/src/test/kotlin/nl/tulipsolutions/keyderivation/Bip84SerdeTest.kt
@@ -14,12 +14,15 @@
 
 package nl.tulipsolutions.keyderivation
 
+import nl.tulipsolutions.BCmath.ECMathProviderImpl
 import org.assertj.core.api.Assertions
 import org.bouncycastle.util.encoders.Hex
 import org.junit.Test
 
 @kotlin.ExperimentalUnsignedTypes
 class Bip84SerdeTest {
+
+    val ecMathProvider = ECMathProviderImpl
 
     private val rootPub = "zpub6jftahH18ngZxLmXaKw3GSZzZsszmt9WqedkyZdezFtWRFBZqsQH5hyUmb4pCEeZGmVfQuP5bedXTB8is6fTv" +
         "19U1GQRyQUKQGUTzyHACMF"
@@ -44,8 +47,7 @@ class Bip84SerdeTest {
     // Account 0, first change address = m/84'/0'/0'/1/0
     private val pubkeyFirstChange = "03025324888e429ab8e3dbaf1f7802648b9cd01e9b418485c5fa4c1b9b5700e1a6"
     private val addressFirstChange = "bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el"
-
-    private val serde = Bip84Serde()
+    private val serde = Bip84Serde(ecMathProvider)
 
     @Test
     fun testPubAndPrivSerializationRoot() {

--- a/src/test/kotlin/nl/tulipsolutions/keyderivation/ExtendedKeyWrapperTest.kt
+++ b/src/test/kotlin/nl/tulipsolutions/keyderivation/ExtendedKeyWrapperTest.kt
@@ -14,6 +14,7 @@
 
 package nl.tulipsolutions.keyderivation
 
+import nl.tulipsolutions.BCmath.ECMathProviderImpl
 import nl.tulipsolutions.byteutils.Hex
 import nl.tulipsolutions.byteutils.decodeBase58
 import nl.tulipsolutions.mnemonic.toSeed
@@ -50,45 +51,45 @@ class ExtendedKeyWrapperTest {
 
     @Test
     fun testBytesConstructor() {
-        val buildBip32FromBytes = ExtendedKeyWrapper(Hex.decode(testVec1xPubHex))
+        val buildBip32FromBytes = ExtendedKeyWrapper(ECMathProviderImpl, Hex.decode(testVec1xPubHex))
         Assertions.assertThat(buildBip32FromBytes.serializeExtKey()).isEqualTo(testVec1MxPubEncoded)
     }
 
     @Test
     fun testXpubStringConstructor() {
-        val buildBip32FromString = ExtendedKeyWrapper(testVec1MxPubEncoded)
+        val buildBip32FromString = ExtendedKeyWrapper(ECMathProviderImpl, testVec1MxPubEncoded)
         Assertions.assertThat(buildBip32FromString.serializeExtKey()).isEqualTo(testVec1MxPubEncoded)
 
-        val buildBip32Priv = ExtendedKeyWrapper(testVec1MxPrivEncoded)
+        val buildBip32Priv = ExtendedKeyWrapper(ECMathProviderImpl, testVec1MxPrivEncoded)
         Assertions.assertThat(buildBip32Priv.serializeExtKey()).isEqualTo(testVec1MxPrivEncoded)
     }
 
     @Test
     fun testZpubStringConstructor() {
-        val buildBip84FromString = ExtendedKeyWrapper(BIP84rootPub)
+        val buildBip84FromString = ExtendedKeyWrapper(ECMathProviderImpl, BIP84rootPub)
         Assertions.assertThat(buildBip84FromString.serializeExtKey()).isEqualTo(BIP84rootPub)
 
-        val buildBip84Priv = ExtendedKeyWrapper(BIP84rootPriv)
+        val buildBip84Priv = ExtendedKeyWrapper(ECMathProviderImpl, BIP84rootPriv)
         Assertions.assertThat(buildBip84Priv.serializeExtKey()).isEqualTo(BIP84rootPriv)
     }
 
     @Test
     fun testDeriveBip32Child() {
-        val buildBip32FromString = ExtendedKeyWrapper(testVec1MxPrivEncoded)
+        val buildBip32FromString = ExtendedKeyWrapper(ECMathProviderImpl, testVec1MxPrivEncoded)
         val derived = buildBip32FromString.deriveChild(HARDENED_KEY_ZERO)
         Assertions.assertThat(derived.serializeExtKey()).isEqualTo(testVec1M0HXPrivEncoded)
     }
 
     @Test
     fun testDeriveBip84Child() {
-        val buildBip84FromString = ExtendedKeyWrapper(m84slash0slash0xPriv)
+        val buildBip84FromString = ExtendedKeyWrapper(ECMathProviderImpl, m84slash0slash0xPriv)
         val derived = buildBip84FromString.deriveChild(0).deriveChild(0)
         Assertions.assertThat(derived.getPublicKey()).isEqualTo(Hex.decode(m84PubkeyFirst))
     }
 
     @Test
     fun getAddressBip84() {
-        val buildBip84FromString = ExtendedKeyWrapper(m84slash0slash0xPriv)
+        val buildBip84FromString = ExtendedKeyWrapper(ECMathProviderImpl, m84slash0slash0xPriv)
         val derived = buildBip84FromString.deriveChild(0).deriveChild(0)
         Assertions.assertThat(derived.getAddress()).isEqualTo(m84AddressFirst)
     }
@@ -98,8 +99,9 @@ class ExtendedKeyWrapperTest {
         mnemonicTestVectors.values.flatten().forEach { vector: MnemonicTestVectorEntry ->
             Assertions.assertThat(
                 ExtendedKeyWrapper(
+                    ECMathProviderImpl,
                     seed = vector.mnemonic.split(" ").toSeed(vector.passphrase),
-                    serde = Bip32Serde(),
+                    serde = Bip32Serde(ECMathProviderImpl),
                     isMainNet = true
                 ).serializeExtKey().decodeBase58()
 
@@ -111,8 +113,9 @@ class ExtendedKeyWrapperTest {
     fun testBip84MnemonicToZpriv() {
         Assertions.assertThat(
             ExtendedKeyWrapper(
+                ECMathProviderImpl,
                 seed = BIP84rootMnemonic.split(" ").toSeed(""),
-                serde = Bip84Serde(),
+                serde = Bip84Serde(ECMathProviderImpl),
                 isMainNet = true
             ).serializeExtKey()
         ).isEqualTo(BIP84rootPriv)


### PR DESCRIPTION
This allows us to later add other implementations such as Libsecp256k1 C
bindings, Java applet specific APIs etc.

Note: still have a dependency on bouncy castle due to the ripemd160